### PR TITLE
scopes: add DMS (burris XTR) w/o adjustments

### DIFF
--- a/addons/scopes/$PBOPREFIX$
+++ b/addons/scopes/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tacgt\addons\scopes

--- a/addons/scopes/CfgWeapons.hpp
+++ b/addons/scopes/CfgWeapons.hpp
@@ -1,0 +1,23 @@
+class CfgWeapons {
+    class optic_DMS;
+    class optic_DMS_ghex_F;
+    class optic_DMS_weathered_F;
+    class optic_DMS_snake_lxWS;
+
+    class CLASS(optic_DMS): optic_DMS {
+        displayName = "Burris XTR III";
+        MACRO_NULL_SCOPE;
+    };
+    class CLASS(optic_DMS_ghex): optic_DMS_ghex_F {
+        displayName = "Burris XTR III (Green Hex)";
+        MACRO_NULL_SCOPE;
+    };
+    class CLASS(optic_DMS_weathered): optic_DMS_weathered_F {
+        displayName = "Burris XTR III (Old)";
+        MACRO_NULL_SCOPE;
+    };
+    class CLASS(optic_DMS_snake): optic_DMS_snake_lxWS {
+        displayName = "Burris XTR III (Snake)";
+        MACRO_NULL_SCOPE;
+    };
+};

--- a/addons/scopes/config.cpp
+++ b/addons/scopes/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "tacgt_main",
+            "cba_jr",
+            "data_f_lxWS_Loadorder"
+        };
+        author = ECSTRING(main,Author);
+        authors[] = {"thisconnect"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgWeapons.hpp"
+#include "rails.hpp"

--- a/addons/scopes/rails.hpp
+++ b/addons/scopes/rails.hpp
@@ -1,0 +1,10 @@
+class asdg_OpticRail;
+
+class asdg_OpticRail1913: asdg_OpticRail {
+    class compatibleItems {
+        CLASS(optic_DMS) = 1;
+        CLASS(optic_DMS_ghex) = 1;
+        CLASS(optic_DMS_weathered) = 1;
+        CLASS(optic_DMS_snake) = 1;
+    };
+};

--- a/addons/scopes/script_component.hpp
+++ b/addons/scopes/script_component.hpp
@@ -1,0 +1,6 @@
+#define COMPONENT scopes
+#define COMPONENT_BEAUTIFIED Scopes
+#include "\x\tacgt\addons\main\script_mod.hpp"
+#include "\x\tacgt\addons\main\script_macros.hpp"
+
+#include "script_macros.hpp"

--- a/addons/scopes/script_macros.hpp
+++ b/addons/scopes/script_macros.hpp
@@ -1,0 +1,5 @@
+#define MACRO_NULL_SCOPE \
+        ACE_ScopeAdjust_Vertical[] = {0, 0}; \
+        ACE_ScopeAdjust_Horizontal[] = {0, 0}; \
+        ACE_ScopeAdjust_VerticalIncrement = 0; \
+        ACE_ScopeAdjust_HorizontalIncrement = 0


### PR DESCRIPTION
Tbh this is the silly method of zeroing out ace mills adjustments
<img width="263" height="196" alt="image" src="https://github.com/user-attachments/assets/bc3d1b7d-c759-4e96-9231-00c9b8891b13" />


the true solution would be to go before ace changes the scope
