### PR TITLE
soft launch for GMM and NSAM

### DIFF
--- a/addons/launchers/CfgAmmo.hpp
+++ b/addons/launchers/CfgAmmo.hpp
@@ -26,6 +26,12 @@ class CfgAmmo {
         triggerOnImpact = 1;
         thrust = 40;
         thrustTime = 0.5;
+        // backblast from nlaw (soft launch)
+        ace_overpressure_priority = 2;
+        ace_overpressure_range = 2;
+        ace_overpressure_offset = 1.05;
+        ace_overpressure_angle = 30;
+        ace_overpressure_backblastRange = 1;
         class Eventhandlers {
             fired = QUOTE(call ace_missile_clgp_fnc_submunition_ammoFired);
         };

--- a/addons/launchers/antiair/CfgAmmo.hpp
+++ b/addons/launchers/antiair/CfgAmmo.hpp
@@ -17,6 +17,12 @@ class CfgAmmo {
         thrust = 190; // half thrust so it doesnt go crazy with LOAL
         thrustTime = 4.5; // twice the time to match
         deflecting = 1; // thrust vectoring so LOAL doesnt make it miss _all_the_time_
+        // soft launch from nlaw
+        ace_overpressure_priority = 2;
+        ace_overpressure_range = 2;
+        ace_overpressure_offset = 1.05;
+        ace_overpressure_angle = 30;
+        ace_overpressure_backblastRange = 1;
         class ace_missileguidance: CLASS(missileguidance_type_NSAM_LOAL) {
             enabled = 1;
         };


### PR DESCRIPTION
add soft launch for GMM and NSAM, as they have slow primary ejection and are heavy enough for small countermass before missile motor lights
