### PR TITLE
45ACP specify ammo, add +P FMJ

### DIFF
--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -117,16 +117,34 @@ class CfgAmmo {
     };
 
     // .45ACP
+    // ballistics from http://ballisticsbytheinch.com/45auto2.html
     class CLASS(45ACP_Ball): B_45ACP_Ball {
-        //FIXME: steal some kind of advanced ballistics from jca or ace?
         aiAmmoUsageFlags = 192;
         caliber = 0.15;
         cartridge = "FxCartridge_9mm";
         hit = 11;
         MACRO_TRACERS;
+        // Federal230 gr.Hydra-ShokJHP
+        //                        3.75"   4.5"  16.6"
+        ACE_barrelLengths[]    = {95.25, 114.3, 421.6};
+        ACE_muzzleVelocities[] = {243.8, 268.2, 308.7};
     };
     class CLASS(45ACP_JHP): CLASS(45ACP_Ball) {
         hit = 14;
+        // Federal230 gr.Hydra-ShokJHP
+        //                        3.75"   4.5"  16.6"
+        ACE_barrelLengths[]    = {95.25, 114.3, 421.6};
+        ACE_muzzleVelocities[] = {247.2, 272.2, 315.2};
+    };
+    class CLASS(45ACP_Ball_P): CLASS(45ACP_Ball) {
+        // +P FMJ round
+        // more barrier penetration and more speed from +P
+        // Not for 1911 as its not strong enough
+        caliber = 0.2;
+        // Buffalo 45ACP +P FMJ-FN
+        //                       3.0"    5.0"   16.0"
+        ACE_barrelLengths[]    = {76.20, 127.3, 406.4};
+        ACE_muzzleVelocities[] = {276.0, 314.0, 354.5};
     };
 
     // .357 Magnum

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -128,7 +128,6 @@ class CfgAmmo {
     class CLASS(45ACP_JHP): CLASS(45ACP_Ball) {
         hit = 14;
         ACE_ballisticCoefficients[] = {0.227};
-        ACE_bulletMass = 14.9;
         // Federal230 gr.Hydra-ShokJHP
         //                        3.75"   4.5"  16.6"
         ACE_barrelLengths[]    = {95.25, 114.3, 421.6};

--- a/addons/ammunition/CfgAmmo.hpp
+++ b/addons/ammunition/CfgAmmo.hpp
@@ -124,13 +124,11 @@ class CfgAmmo {
         cartridge = "FxCartridge_9mm";
         hit = 11;
         MACRO_TRACERS;
-        // Federal230 gr.Hydra-ShokJHP
-        //                        3.75"   4.5"  16.6"
-        ACE_barrelLengths[]    = {95.25, 114.3, 421.6};
-        ACE_muzzleVelocities[] = {243.8, 268.2, 308.7};
     };
     class CLASS(45ACP_JHP): CLASS(45ACP_Ball) {
         hit = 14;
+        ACE_ballisticCoefficients[] = {0.227};
+        ACE_bulletMass = 14.9;
         // Federal230 gr.Hydra-ShokJHP
         //                        3.75"   4.5"  16.6"
         ACE_barrelLengths[]    = {95.25, 114.3, 421.6};
@@ -141,6 +139,7 @@ class CfgAmmo {
         // more barrier penetration and more speed from +P
         // Not for 1911 as its not strong enough
         caliber = 0.2;
+        ACE_ballisticCoefficients[] = {0.196};
         // Buffalo 45ACP +P FMJ-FN
         //                       3.0"    5.0"   16.0"
         ACE_barrelLengths[]    = {76.20, 127.3, 406.4};

--- a/addons/ammunition/bi/45ACP.hpp
+++ b/addons/ammunition/bi/45ACP.hpp
@@ -10,6 +10,10 @@ class CLASS(15Rnd_45ACP_FNX45_JHP): CLASS(15Rnd_45ACP_FNX45_Ball) {
     ammo = QCLASS(45ACP_JHP);
     AMMO_DESCRIPTION(.45ACP,JHP,15,Reload Tracer,FNX);
 };
+class CLASS(15Rnd_45ACP_FNX45_Ball_P): CLASS(15Rnd_45ACP_FNX45_Ball) {
+    ammo = QCLASS(45ACP_Ball_P);
+    AMMO_DESCRIPTION(.45ACP,Ball +P,15,Reload Tracer,FNX);
+};
 
 // .45ACP C-1911
 class CLASS(8Rnd_45ACP_C1911_Ball): 9Rnd_45ACP_Mag {

--- a/addons/ammunition/bi/45ACP.hpp
+++ b/addons/ammunition/bi/45ACP.hpp
@@ -45,6 +45,11 @@ class CLASS(25Rnd_45ACP_JHP): CLASS(25Rnd_45ACP_Ball) {
     ammo = QCLASS(45ACP_JHP);
     AMMO_DESCRIPTION(.45ACP,JHP,25,Reload Tracer,Glock);
 };
+class CLASS(25Rnd_45ACP_Ball_P): CLASS(25Rnd_45ACP_Ball) {
+    ammo = QCLASS(45ACP_Ball_P);
+    AMMO_DESCRIPTION(.45ACP,Ball +P,25,Reload Tracer,Glock);
+};
+
 //revolver
 class CLASS(6Rnd_45ACP_Ball_Cylinder): 6Rnd_45ACP_Cylinder {
     MACRO_SCOPE;

--- a/addons/ammunition/jca_mk23/CfgMagazineWells.hpp
+++ b/addons/ammunition/jca_mk23/CfgMagazineWells.hpp
@@ -1,6 +1,7 @@
 class CfgMagazineWells {
     class JCA_Mk23_45ACP {
         ADDON[] = {
+            QCLASS(12Rnd_45ACP_Ball_P_Mk23_JCA),
             QCLASS(12Rnd_45ACP_Ball_Mk23_JCA),
             QCLASS(12Rnd_45ACP_JHP_Mk23_JCA),
         };

--- a/addons/ammunition/jca_mk23/CfgMagazines.hpp
+++ b/addons/ammunition/jca_mk23/CfgMagazines.hpp
@@ -7,6 +7,13 @@ class CfgMagazines {
         tracersEvery = 4;
         AMMO_DESCRIPTION(45ACP,Ball,12,Reload Tracer,Mk23);
     };
+    class CLASS(12Rnd_45ACP_Ball_P_Mk23_JCA): CLASS(12Rnd_45ACP_Ball_Mk23_JCA {
+        MACRO_SCOPE;
+        ammo = QCLASS(45ACP_Ball_P);
+        lastRoundsTracer = 2;
+        tracersEvery = 4;
+        AMMO_DESCRIPTION(45ACP,Ball +P,12,Reload Tracer,Mk23);
+    };
     class CLASS(12Rnd_45ACP_JHP_Mk23_JCA): CLASS(12Rnd_45ACP_Ball_Mk23_JCA) {
         ammo = QCLASS(45ACP_Ball);
         AMMO_DESCRIPTION(45ACP,JHP,12,Reload Tracer,Mk23);

--- a/addons/ammunition/jca_ump45/CfgMagazineWells.hpp
+++ b/addons/ammunition/jca_ump45/CfgMagazineWells.hpp
@@ -1,8 +1,9 @@
 class CfgMagazineWells {
     class JCA_UMP_45ACP {
         ADDON[] = {
+            QCLASS(25Rnd_45ACP_Ball_P_UMP_JCA),
             QCLASS(25Rnd_45ACP_Ball_UMP_JCA),
-            QCLASS(25Rnd_45ACP_JHP_UMP_JCA)
+            QCLASS(25Rnd_45ACP_JHP_UMP_JCA),
         };
     };
 };

--- a/addons/ammunition/jca_ump45/CfgMagazines.hpp
+++ b/addons/ammunition/jca_ump45/CfgMagazines.hpp
@@ -10,4 +10,8 @@ class CfgMagazines {
         ammo = QCLASS(45ACP_JHP);
         AMMO_DESCRIPTION(45ACP,JHP,25,Reload Tracer,UMP);
     };
+    class CLASS(25Rnd_45ACP_Ball_P_UMP_JCA): CLASS(25Rnd_45ACP_Ball_UMP_JCA) {
+        ammo = QCLASS(45ACP_Ball_P);
+        AMMO_DESCRIPTION(45ACP,Ball +P,25,Reload Tracer,UMP);
+    };
 };

--- a/addons/ammunition/magwells/handgun.hpp
+++ b/addons/ammunition/magwells/handgun.hpp
@@ -18,6 +18,7 @@ class CBA_45ACP_FNX45 {
     ADDON[] = {
       QCLASS(15Rnd_45ACP_FNX45_Ball),
       QCLASS(15Rnd_45ACP_FNX45_JHP),
+      QCLASS(15Rnd_45ACP_FNX45_Ball_P),
     };
 };
 

--- a/addons/ammunition/magwells/rifle.hpp
+++ b/addons/ammunition/magwells/rifle.hpp
@@ -77,6 +77,7 @@ class CBA_545x39_AK {
 
 class CBA_45ACP_Glock_Full {
     ADDON[] = {
+        QCLASS(25Rnd_45ACP_Ball_P),
         QCLASS(25Rnd_45ACP_Ball),
         QCLASS(25Rnd_45ACP_Ball_Tracer),
         QCLASS(25Rnd_45ACP_JHP),


### PR DESCRIPTION
**When merged this pull request will:**

-  Specify velocity for existing JHP and FMJ rounds
- Add +P FMJ loadings

UMP45 - 279m/s -> 325m/s
FNX45 - 268m/s -> 304m/s
and slightly more base penetration

this makes it roughly the same as 9mm ball in calculated penetration
