### PR TITLE
fix cba disposable nsam mass

### DIFF
--- a/addons/launchers/antiair/CfgWeapons.hpp
+++ b/addons/launchers/antiair/CfgWeapons.hpp
@@ -22,7 +22,7 @@ class CfgWeapons {
         magazines[] = {};
         magazineWell[] = {};
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 50;
+            mass = 150;
         };
         // backblast from nlaw ("soft launch")
         ace_overpressure_angle = 30;
@@ -39,6 +39,9 @@ class CfgWeapons {
         class EventHandlers {
             fired = "call CBA_fnc_firedDisposable";
         };
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            mass = 50;
+        };
     };
     class CLASS(launch_NSAM_used_F): CLASS(launch_NSAM_F) {
         scope = 1;
@@ -50,7 +53,7 @@ class CfgWeapons {
         descriptionShort = "empty";
         weaponPoolAvailable = 0;
         class WeaponSlotsInfo: WeaponSlotsInfo {
-            mass = 45;
+            mass = 50;
         };
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**

- fix CBA warnings about disposable

```
22:29:55 [CBA] (disposable) WARNING: Mass of launcher synixe_armoury_launch_NSAM_ready_F (50) is different from mass of used launcher synixe_armoury_launch_NSAM_used_F (45).
22:29:55 [CBA] (disposable) WARNING: Sum of mass of launcher synixe_armoury_launch_NSAM_ready_F and mass of magazine synixe_armoury_NSAM_LOBL (50+100=150) is different from mass of loaded launcher synixe_armoury_launch_NSAM_F (50).
```