### PR TITLE
GMM add laser codes, fix launcher cfgpatches error

### DIFF
--- a/addons/launchers/antiair/config.cpp
+++ b/addons/launchers/antiair/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = COMPONENT_NAME;
+    class DOUBLES(ADDON,SUBCOMPONENT) {
+        name = QUOTE(DOUBLES(COMPONENT,SUBCOMPONENT));
         units[] = {};
         weapons[] = {
             QCLASS(launch_NSAM_F),

--- a/addons/launchers/antiair/script_component.hpp
+++ b/addons/launchers/antiair/script_component.hpp
@@ -1,4 +1,3 @@
-#define COMPONENT launchers_aa
-#define COMPONENT_BEAUTIFIED Launchers Anti Air
-#include "\s\synixe_armoury\addons\main\script_mod.hpp"
-#include "\s\synixe_armoury\addons\main\script_macros.hpp"
+#define SUBCOMPONENT aa
+
+#include "..\script_component.hpp"

--- a/addons/launchers/maaws/CfgWeapons.hpp
+++ b/addons/launchers/maaws/CfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons {
+    class Launcher_Base_F;
+    class launch_MRAWS_base_F: Launcher_Base_F {
+        ace_laser_canSelect = 1; // can ace_laser lock (allows switching laser code)
+    };
+};

--- a/addons/launchers/maaws/config.cpp
+++ b/addons/launchers/maaws/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = COMPONENT_NAME;
+    class DOUBLES(ADDON,SUBCOMPONENT) {
+        name = QUOTE(DOUBLES(COMPONENT,SUBCOMPONENT));
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/launchers/maaws/config.cpp
+++ b/addons/launchers/maaws/config.cpp
@@ -18,3 +18,4 @@ class CfgPatches {
 #include "CfgAmmo.hpp"
 #include "CfgMagazines.hpp"
 #include "CfgMagazineWells.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/launchers/maaws/script_component.hpp
+++ b/addons/launchers/maaws/script_component.hpp
@@ -1,6 +1,3 @@
-#define COMPONENT launchers
-#define COMPONENT_BEAUTIFIED Launchers Carl Gustav
-#include "\s\synixe_armoury\addons\main\script_mod.hpp"
-#include "\s\synixe_armoury\addons\main\script_macros.hpp"
+#define SUBCOMPONENT maaws
 
-#include "../script_macros.hpp"
+#include "..\script_component.hpp"

--- a/addons/launchers/rpg32/CfgWeapons.hpp
+++ b/addons/launchers/rpg32/CfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons {
+    class Launcher_Base_F;
+    class launch_RPG32_F: Launcher_Base_F {
+        ace_laser_canSelect = 1; // can ace_laser lock (allows switching laser code)
+    };
+};

--- a/addons/launchers/rpg32/CfgWeapons.hpp
+++ b/addons/launchers/rpg32/CfgWeapons.hpp
@@ -1,6 +1,0 @@
-class CfgWeapons {
-    class Launcher_Base_F;
-    class launch_RPG32_F: Launcher_Base_F {
-        ace_laser_canSelect = 1; // can ace_laser lock (allows switching laser code)
-    };
-};

--- a/addons/launchers/rpg32/config.cpp
+++ b/addons/launchers/rpg32/config.cpp
@@ -14,7 +14,5 @@ class CfgPatches {
     };
 };
 
-
 #include "CfgMagazines.hpp"
 #include "CfgMagazineWells.hpp"
-#include "CfgWeapons.hpp"

--- a/addons/launchers/rpg32/config.cpp
+++ b/addons/launchers/rpg32/config.cpp
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 class CfgPatches {
-    class ADDON {
-        name = COMPONENT_NAME;
+    class DOUBLES(ADDON,SUBCOMPONENT) {
+        name = QUOTE(DOUBLES(COMPONENT,SUBCOMPONENT));
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/launchers/rpg32/config.cpp
+++ b/addons/launchers/rpg32/config.cpp
@@ -17,3 +17,4 @@ class CfgPatches {
 
 #include "CfgMagazines.hpp"
 #include "CfgMagazineWells.hpp"
+#include "CfgWeapons.hpp"

--- a/addons/launchers/rpg32/script_component.hpp
+++ b/addons/launchers/rpg32/script_component.hpp
@@ -1,6 +1,3 @@
-#define COMPONENT launchers
-#define COMPONENT_BEAUTIFIED Launchers RPG32
-#include "\s\synixe_armoury\addons\main\script_mod.hpp"
-#include "\s\synixe_armoury\addons\main\script_macros.hpp"
+#define SUBCOMPONENT rpg32
 
-#include "../script_macros.hpp"
+#include "..\script_component.hpp"


### PR DESCRIPTION
**When merged this pull request will:**

- Add ability to select codes for GMM missiles
- Fix CfgPatches error in nested conflicting modules

```
18:13:12 Conflicting addon synixe_armoury_launchers in 's\synixe_armoury\addons\launchers\', previous definition in 's\synixe_armoury\addons\launchers\rpg32\'
18:13:12 Conflicting addon synixe_armoury_launchers in 's\synixe_armoury\addons\launchers\maaws\', previous definition in 's\synixe_armoury\addons\launchers\rpg32\'
18:13:13 Config 's\synixe_armoury\addons\launchers\maaws\config.bin' contains a duplicate CfgPatches entry 'synixe_armoury_launchers', which was previously defined in 's\synixe_armoury\addons\launchers\config.bin', the duplicate is SKIPPED.
18:13:13 Config 's\synixe_armoury\addons\launchers\rpg32\config.bin' contains a duplicate CfgPatches entry 'synixe_armoury_launchers', which was previously defined in 's\synixe_armoury\addons\launchers\config.bin', the duplicate is SKIPPED.
```
